### PR TITLE
Revert "FEATURE #63: Run CI only on push"

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,11 +1,18 @@
 name: CI
 
-on: push
+on: [push, pull_request]
 
 jobs:
   install:
     name: Install dependencies
     runs-on: ubuntu-latest
+    if: >-
+      github.event_name == 'push' ||
+      (
+        github.event_name == 'pull_request' &&
+        github.event.pull_request.user.login == 'branoholy-bot' &&
+        (github.head_ref == 'deps-update-lock-file' || github.head_ref == 'build-update-dist')
+      )
     steps:
       - name: Checkout
         uses: actions/checkout@v2.1.0

--- a/.github/workflows/merge-pr.yaml
+++ b/.github/workflows/merge-pr.yaml
@@ -23,7 +23,8 @@ jobs:
         (
           github.event.commit.author.login == 'dependabot[bot]' ||
           github.event.commit.author.login == 'dependabot-preview[bot]' ||
-          github.event.commit.author.login == 'branoholy-bot'
+          contains(github.event.branches.*.name, 'deps-update-lock-file') ||
+          contains(github.event.branches.*.name, 'build-update-dist')
         )
       )
     steps:

--- a/.github/workflows/update-dist.yaml
+++ b/.github/workflows/update-dist.yaml
@@ -29,5 +29,6 @@ jobs:
           paths: dist/index.js
           branch: build-update-dist
           commit-message: 'BUILD: Update dist'
+          commit-token: ${{ secrets.GITHUB_TOKEN }}
           body: Automatic update of `dist/index.js`.
           reviewers: branoholy

--- a/.github/workflows/update-lock-file.yaml
+++ b/.github/workflows/update-lock-file.yaml
@@ -24,6 +24,7 @@ jobs:
           paths: package-lock.json
           branch: deps-update-lock-file
           commit-message: 'DEPS: Update lock file'
+          commit-token: ${{ secrets.GITHUB_TOKEN }}
           body: Automatic update of dependencies in `package-lock.json`.
           labels: dependencies
           reviewers: branoholy


### PR DESCRIPTION
It seems to be necessary to use `secrets.GITHUB_TOKEN` to have signed commits.

Reverts #64
Closes #67