### PR TITLE
BUGFIX #644: Run CI only when triggered with the Starting description

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -9,6 +9,7 @@ jobs:
   install:
     name: Install dependencies
     runs-on: ubuntu-latest
+    if: github.event.context == 'CI / Status' && github.event.description == 'Starting'
     steps:
       - name: Send CI status (In progress)
         run: >-


### PR DESCRIPTION
Closes #644 